### PR TITLE
Create window on interact if it does not exists

### DIFF
--- a/overlay.js
+++ b/overlay.js
@@ -297,7 +297,11 @@ class Overlay {
 
 	//open or close overlay window
 	interact() {
-		if(!this._win) return;
+		if(!this._win) {
+			//re-create overlay window and show
+			this._create(() => this.show());
+			return;
+		}
 
 		if(!this._win.isVisible())
 			this.show();


### PR DESCRIPTION
This PR adds a few lines of code that force window re-creation on interact if it doesn't exist.
Addresses the issue that appears if you accidentally close the overlay window, but HyperTerm itself is still running - there's no way to re-open overlay window once it has been destroyed (aside from clicking on toolbar icon which requires using mouse).
