### PR TITLE
Add overlay onStartup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ module.exports = {
       position: 'top',
       primaryDisplay: false,
       startup: false,
+      onStartup: false,
       size: 0.4,
       tray: true,
       unique: false
@@ -95,6 +96,12 @@ module.exports = {
 - Value: true or false
 - Default: true
 - Open HyperTerm Overlay on HyperTerm startup.
+
+### onStartup
+- Value: true or false
+- Default: false
+- Makes HyperTerm Overlay the unique window displayed when started.
+- Other windows started will be default HyperTerm windows.
 
 ### size
 - Value: float or number

--- a/overlay.js
+++ b/overlay.js
@@ -45,8 +45,15 @@ class Overlay {
 		//creating the overlay window
 		this._create(() => {
 			//open on startup
-			if((startup && this._config.startup) || this._forceStartup)
+			if((startup && this._config.startup) || this._forceStartup) {
 				this.show();
+				if(this._config.onStartup) {
+					this._app.getWindows().forEach(win => {
+						if(win != this._win)
+							win.close();
+					});
+				}
+			}
 		});
 	}
 
@@ -121,7 +128,7 @@ class Overlay {
 				this._app.dock.hide();
 			else if(this._config.unique && this._config.hideDock)
 				this._app.dock.show();
-
+				
 			//removing the initial windows of hyperterm
 			if(userConfig.unique && !this._config.unique) {
 				this._app.getWindows().forEach(win => {
@@ -143,6 +150,7 @@ class Overlay {
 			position: 'top',
 			primaryDisplay: false,
 			startup: false,
+			onStartup: false,
 			size: 0.4,
 			tray: true,
 			unique: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperterm-overlay",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A complete and customizable solution for a permanent, dropdown, hotkey and overlay window in your HyperTerm.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add onStartup option to configuration.
- Default behavior is to start overlay as the only window when Hyperterm is started.
- Other windows are started as normal. 
