### PR TITLE
Added statusbar height to bounds calculation for bottom

### DIFF
--- a/overlay.js
+++ b/overlay.js
@@ -235,7 +235,7 @@ class Overlay {
 			break;
 		case 'bottom':
 			size = (this._config.size > 1) ? this._config.size : Math.round(height * this._config.size);
-			this._win.setBounds({ x: x, y: height - size, width: width, height: size }, this._config.animate);
+			this._win.setBounds({ x: x, y: y + height - size, width: width, height: size }, this._config.animate);
 			break;
 		case 'right':
 			size = (this._config.size > 1) ? this._config.size : Math.round(width * this._config.size);


### PR DESCRIPTION
I had the problem, that the position of the overlay was not correctly calculated if the position is set to bottom. It seems like the statusbar on OS X was not added to the position.