### PR TITLE
Show Hyper on top of fullscreen apps

### DIFF
--- a/overlay.js
+++ b/overlay.js
@@ -192,7 +192,7 @@ class Overlay {
 	_setConfigs(win) {
 		win.setHasShadow(this._config.hasShadow);
 		win.setResizable(this._config.resizable);
-		win.setAlwaysOnTop(this._config.alwaysOnTop);
+		win.setAlwaysOnTop(this._config.alwaysOnTop, 'screen');
 	}
 
 	//get current display


### PR DESCRIPTION
Setting `win.setAlwaysOnTop` to true is not enough to allow Hyper to show up on top of full screen apps. We need to pass in the optional 'level' parameter.