### PR TITLE
Fix restore focus back to previous application, fixes #38

### DIFF
--- a/overlay.js
+++ b/overlay.js
@@ -364,6 +364,7 @@ class Overlay {
 		//close without animation
 		else {
 			findFocus();
+			this._win.minimize();
 			this._win.hide();
 		}
 


### PR DESCRIPTION
- fixes #38
- fix is only working when **animation is turned off** in user config
- if the window is minimized before hiding it, focus will be properly restored to previous application