### PR TITLE
Activated window is shown on current MacOS workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ⚠️⚠️ DISCLAIMER ⚠️⚠️
-Since the original project is not actively developed anymore I forked it and fixed a super annoying bug for MacOS. For convenience I published the project under as an NPM package with a DIFFERENT NAME.
+Since the original project is not actively developed anymore I forked it and fixed a super annoying bug for MacOS. For convenience I published the project as an NPM package with a DIFFERENT NAME.
 
 # HyperTerm Overlay
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DISCLAIMER
+Since the original project is not actively developed anymore I forked it and fixed a super annoying bug for MacOS. For convenience I published the project under as an NPM package with a DIFFERENT NAME.
+
 # HyperTerm Overlay
 
 A complete and customizable solution for a permanent / dropdown / hotkey / overlay window in your Hyper.app, accessible via hotkeys and/or toolbar icon (tray).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DISCLAIMER
+# ⚠️⚠️ DISCLAIMER ⚠️⚠️
 Since the original project is not actively developed anymore I forked it and fixed a super annoying bug for MacOS. For convenience I published the project under as an NPM package with a DIFFERENT NAME.
 
 # HyperTerm Overlay

--- a/overlay.js
+++ b/overlay.js
@@ -324,7 +324,9 @@ class Overlay {
 		}
 
 		//show and focus window
+    this._win.setVisibleOnAllWorkspaces(true);
 		this._win.show();
+    this._win.setVisibleOnAllWorkspaces(false)
 		this._win.focus();
 
 		//set end bounds

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "hyperterm-overlay",
-  "version": "0.4.0",
+  "name": "hyperterminal-overlay",
+  "version": "0.4.1",
   "description": "A complete and customizable solution for a permanent, dropdown, hotkey and overlay window in your Hyper.app",
   "main": "index.js",
   "scripts": {
     "test": "npm run lint",
-	"lint": "eslint ."
+	  "lint": "eslint ."
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rickgbw/hyperterm-overlay.git"
+    "url": "https://github.com/D0miH/hyperterm-overlay.git"
   },
   "author": "rickgbw",
   "keywords": [
@@ -25,13 +25,13 @@
     "guake",
     "yakuake",
     "dropdown",
-	"iterm2"
+	  "iterm2"
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/rickgbw/hyperterm-overlay/issues"
+    "url": "https://github.com/D0miH/hyperterm-overlay/issues"
   },
-  "homepage": "https://github.com/rickgbw/hyperterm-overlay",
+  "homepage": "https://github.com/D0miH/hyperterm-overlay",
   "dependencies": {},
   "devDependencies": {
     "eslint": "^3.1.1"


### PR DESCRIPTION
Fixed a bug that would switch to the current work space in MacOS when the window is shown.

However, the window is still not shown on the current workspace if another app is running in fullscreen.